### PR TITLE
Quit on serial read errors

### DIFF
--- a/handle.go
+++ b/handle.go
@@ -98,7 +98,7 @@ func (h *Handler) messageReader(c chan *Message) {
 	for {
 		d, err := r.ReadBytes('\x0a')
 		if err != nil {
-			log.Printf("Read error: %v\n", err)
+			log.Fatalf("Read error: %v\n", err)
 			break
 		}
 		m := &Message{}


### PR DESCRIPTION
So docker can restart us.

This is for symmetry with messageWriter, if the serial port gets unplugged

This happened to me a few times this weekend.