### PR TITLE
Remove unnecessary 'installsuffix cgo'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN mkdir /root/app
 COPY go.mod go.sum *.go /root/
 COPY app/*.go /root/app/
 RUN go get -d -v
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm go build -a -installsuffix=cgo app/mysensors.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm go build -a app/mysensors.go
 
 FROM scratch
 


### PR DESCRIPTION
See https://github.com/golang/go/issues/9344#issuecomment-69944514
It's not necessary any more.